### PR TITLE
Fix wait regex parsing

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -47,7 +47,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     // Check for new wait syntax: $wait 30s$ or $wait 2m$
-    const waitTagRegex = /\$wait\s+(\d+)([sm])\$/i;
+    const waitTagRegex = /\$wait\s*(\d+)([sm])\$/i;
     let delayMs = 0;
     let command = promptText;
     const waitMatch = promptText.match(waitTagRegex);
@@ -64,7 +64,7 @@ document.addEventListener("DOMContentLoaded", function () {
       return { command, isPauseCommand: false, delayMs, isDelayCommand: true };
     } else {
       // Legacy support for old sleep syntax: $sleep30s$
-      const sleepTagRegex = /\$sleep(\d+)([sm])\$/i;
+      const sleepTagRegex = /\$sleep\s*(\d+)([sm])\$/i;
       const sleepMatch = promptText.match(sleepTagRegex);
 
       if (sleepMatch) {

--- a/test-commands.js
+++ b/test-commands.js
@@ -29,7 +29,7 @@ function testParseCommand(promptText) {
   }
 
   // Check for new wait syntax: $wait 30s$ or $wait 2m$
-  const waitTagRegex = /\$wait\s+(\d+)([sm])\$/i;
+  const waitTagRegex = /\$wait\s*(\d+)([sm])\$/i;
   let explicitDelayMs = 0;
   let command = promptText;
   const waitMatch = promptText.match(waitTagRegex);
@@ -45,7 +45,7 @@ function testParseCommand(promptText) {
     command = promptText.replace(waitTagRegex, "").trim();
   } else {
     // Legacy support for old sleep syntax: $sleep30s$
-    const sleepTagRegex = /\$sleep(\d+)([sm])\$/i;
+    const sleepTagRegex = /\$sleep\s*(\d+)([sm])\$/i;
     const sleepMatch = promptText.match(sleepTagRegex);
 
     if (sleepMatch) {


### PR DESCRIPTION
## Summary
- allow `$wait30s$` format in popup by making spaces optional
- update test script regex

## Testing
- `node test-commands.js`

------
https://chatgpt.com/codex/tasks/task_e_6840cbbd8ae8832b9655c07711bd9d09