### PR TITLE
Improve state restore timing

### DIFF
--- a/content.js
+++ b/content.js
@@ -1397,10 +1397,18 @@ loadConfig(); // Load config when script initially loads
 // or when a chain starts, or when config is updated.
 
 // --- State Restoration ---
-// Try to restore state after a brief delay to ensure page is loaded
-setTimeout(() => {
-  restoreStateIfAvailable();
-}, 1000);
+// Wait for user messages to load before attempting state restore
+function attemptRestoreState(retries = 10) {
+  const userMsgs = document.querySelectorAll('[data-message-author-role="user"]');
+  if (userMsgs.length > 0 || retries <= 0) {
+    restoreStateIfAvailable();
+  } else {
+    setTimeout(() => attemptRestoreState(retries - 1), 1000);
+  }
+}
+
+// Start initial state restoration attempt
+attemptRestoreState();
 
 // Monitor URL changes to update chat ID and save state
 let lastUrl = window.location.href;


### PR DESCRIPTION
## Summary
- wait for user messages before restoring state

## Testing
- `node test-commands.js`

------
https://chatgpt.com/codex/tasks/task_e_6840d9d975dc832bac2759d9cf91b760