### PR TITLE
Add multi-site adapter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@
    - Click "Load unpacked"
    - Select the extension directory
 
-3. **Navigate to ChatGPT**
-   - Go to [chatgpt.com](https://chatgpt.com)
+3. **Navigate to your AI site**
+   - Visit [chatgpt.com](https://chatgpt.com) or any other supported site
    - The extension icon should appear in your toolbar
 
 ### Basic Usage
@@ -75,6 +75,10 @@
    - Watch the floating control panel for real-time status
    - Pause/resume as needed
    - Navigate between steps when paused
+
+## 🔌 Adding More Websites
+1. Edit `manifest.json` and add the site's URL pattern under `content_scripts.matches`.
+2. Update `siteAdapters.js` with the correct selectors for the new site.
 
 ## 📖 Usage Examples
 
@@ -199,8 +203,8 @@ cd chatgpt-chain-ext
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 
-### Testing
-- Test on various ChatGPT conversation types
+-### Testing
+- Test on various supported conversation sites
 - Verify chain execution with different separators
 - Test pause/resume functionality
 - Validate error handling scenarios
@@ -225,8 +229,8 @@ cd chatgpt-chain-ext
 ## 🤝 Support
 
 ### Common Issues
-- **"Could not establish connection"**: Refresh the ChatGPT page and try again
-- **Extension not working**: Ensure you're on chatgpt.com
+- **"Could not establish connection"**: Refresh the page and try again
+- **Extension not working**: Ensure the website is supported in `manifest.json`
 - **Chains not saving**: Check browser storage permissions
 
 ### Getting Help

--- a/content.js
+++ b/content.js
@@ -1,4 +1,6 @@
 // --- Configuration (loaded from storage, with defaults) ---
+const siteAdapter = getSiteAdapter();
+
 let config = {
   defaultDelayMs: 5000,
   imageThrottleCount: 5,
@@ -793,16 +795,16 @@ function isResponseComplete() {
   // Check if the "Regenerate" button or a similar element indicating completion is visible,
   // and that the send button is enabled.
   const speechButton = document.querySelector(
-    'button[data-testid="composer-speech-button"]'
+    siteAdapter.speechButtonSelector
   );
   // const sendButton = document.querySelector('button[aria-label="Send prompt"][data-testid="send-button"]');
   return speechButton != null; // && (sendButton && !sendButton.disabled);
 }
 
 async function submitPrompt(prompt) {
-  const textarea = document.querySelector("#prompt-textarea");
+  const textarea = document.querySelector(siteAdapter.textareaSelector);
   if (!textarea) {
-    console.error("Textarea #prompt-textarea not found. Stopping sequence.");
+    console.error(`Textarea ${siteAdapter.textareaSelector} not found. Stopping sequence.`);
     await stopSequence();
     throw new Error("Textarea not found");
   }
@@ -825,9 +827,7 @@ async function submitPrompt(prompt) {
         return;
       }
 
-      const button = document.querySelector(
-        'button[aria-label="Send prompt"][data-testid="send-button"]'
-      );
+      const button = document.querySelector(siteAdapter.sendButtonSelector);
 
       // Detect if ChatGPT is still generating a prior response
       const chatgptBusy = !isResponseComplete();
@@ -847,9 +847,7 @@ async function submitPrompt(prompt) {
         return; // Don't increment attempts while waiting
       } else if (attempts >= maxAttempts) {
         // Check for retry button before giving up
-        const retryButton = document.querySelector(
-          'button[data-testid="regenerate-thread-error-button"]'
-        );
+        const retryButton = document.querySelector(siteAdapter.retryButtonSelector);
         if (retryButton) {
           console.log(
             "Send button timeout, but retry button found. Clicking retry..."
@@ -859,9 +857,7 @@ async function submitPrompt(prompt) {
 
           // Wait a bit and try to submit again
           setTimeout(() => {
-            const newButton = document.querySelector(
-              'button[aria-label="Send prompt"][data-testid="send-button"]'
-            );
+            const newButton = document.querySelector(siteAdapter.sendButtonSelector);
             if (newButton && !newButton.disabled) {
               newButton.click();
               console.log(
@@ -886,7 +882,7 @@ async function submitPrompt(prompt) {
       } else if (!button && attempts > 5) {
         // If button disappears after initial checks, look for retry button
         const retryButton = document.querySelector(
-          'button[data-testid="regenerate-thread-error-button"]'
+          siteAdapter.retryButtonSelector
         );
         if (retryButton) {
           console.log(
@@ -898,7 +894,7 @@ async function submitPrompt(prompt) {
           // Wait a bit and try to submit again
           setTimeout(() => {
             const newButton = document.querySelector(
-              'button[aria-label="Send prompt"][data-testid="send-button"]'
+              siteAdapter.sendButtonSelector
             );
             if (newButton && !newButton.disabled) {
               newButton.click();
@@ -1282,7 +1278,7 @@ function loadChatState() {
 // Get all submitted user prompts from the current chat
 function getSubmittedPrompts() {
   const userMessages = document.querySelectorAll(
-    '[data-message-author-role="user"]'
+    siteAdapter.userMessageSelector
   );
   return Array.from(userMessages).map((msg) => msg.textContent.trim());
 }
@@ -1489,7 +1485,7 @@ loadConfig(); // Load config when script initially loads
 // --- State Restoration ---
 // Wait for user messages to load before attempting state restore
 function attemptRestoreState(retries = 10) {
-  const userMsgs = document.querySelectorAll('[data-message-author-role="user"]');
+  const userMsgs = document.querySelectorAll(siteAdapter.userMessageSelector);
   if (userMsgs.length > 0 || retries <= 0) {
     restoreStateIfAvailable();
   } else {
@@ -1540,7 +1536,7 @@ async function retryLastPrompt() {
 
   // Look for retry button first
   const retryButton = document.querySelector(
-    'button[data-testid="regenerate-thread-error-button"]'
+    siteAdapter.retryButtonSelector
   );
   if (retryButton) {
     retryButton.click();

--- a/manifest.json
+++ b/manifest.json
@@ -9,8 +9,12 @@
       "default_path": "sidepanel.html"
    },
    "content_scripts": [ {
-      "js": [ "parseCommand.js", "content.js" ],
-      "matches": [ "https://chatgpt.com/*" ]
+      "js": [ "siteAdapters.js", "parseCommand.js", "content.js" ],
+      "matches": [
+         "https://chatgpt.com/*",
+         "https://gemini.google.com/*",
+         "https://claude.ai/*"
+      ]
    } ],
    "description": "Automate ChatGPT conversations with intelligent prompt chains. Create, save, and execute multi-step workflows with custom starting positions, real-time progress tracking, and advanced controls. Perfect for content creation, research, and repetitive AI tasks.",
    "icons": {

--- a/siteAdapters.js
+++ b/siteAdapters.js
@@ -1,0 +1,41 @@
+(function(){
+  const defaultAdapter = {
+    textareaSelector: '#prompt-textarea',
+    sendButtonSelector: 'button[aria-label="Send prompt"][data-testid="send-button"]',
+    retryButtonSelector: 'button[data-testid="regenerate-thread-error-button"]',
+    speechButtonSelector: 'button[data-testid="composer-speech-button"]',
+    userMessageSelector: '[data-message-author-role="user"]'
+  };
+
+  const adapters = {
+    'chatgpt.com': {}, // uses default selectors
+    'gemini.google.com': {
+      // Update these selectors when integrating Gemini
+      textareaSelector: 'textarea',
+      sendButtonSelector: 'button[type="submit"]',
+      userMessageSelector: '.user-message'
+    },
+    'claude.ai': {
+      // Update these selectors when integrating Claude
+      textareaSelector: 'textarea',
+      sendButtonSelector: 'button[type="submit"]',
+      userMessageSelector: '.user-message'
+    }
+  };
+
+  function getSiteAdapter() {
+    const host = location.hostname;
+    for (const domain in adapters) {
+      if (host === domain || host.endsWith('.' + domain)) {
+        return { ...defaultAdapter, ...adapters[domain] };
+      }
+    }
+    return defaultAdapter;
+  }
+
+  window.getSiteAdapter = getSiteAdapter;
+
+  if (typeof module !== 'undefined') {
+    module.exports = { getSiteAdapter };
+  }
+})();


### PR DESCRIPTION
## Summary
- add `siteAdapters.js` for domain-specific selectors
- refactor `content.js` to use adapter-based selectors
- extend manifest to inject scripts on gemini.google.com and claude.ai
- update README with instructions on adding new websites

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68416fd7ed60832ba022bb15d8529209